### PR TITLE
Fixed problem with non-recursive objects where detected as recursive

### DIFF
--- a/SKON.NET/SKON.NET/Properties/AssemblyInfo.cs
+++ b/SKON.NET/SKON.NET/Properties/AssemblyInfo.cs
@@ -33,5 +33,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.1.0")]
-[assembly: AssemblyFileVersion("0.1.1.0")]
+[assembly: AssemblyVersion("0.1.2.0")]
+[assembly: AssemblyFileVersion("0.1.2.0")]

--- a/SKON.NET/SKON.NET/Properties/AssemblyInfo.cs
+++ b/SKON.NET/SKON.NET/Properties/AssemblyInfo.cs
@@ -33,5 +33,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.2.0")]
-[assembly: AssemblyFileVersion("0.1.2.0")]
+[assembly: AssemblyVersion("0.1.3.0")]
+[assembly: AssemblyFileVersion("0.1.3.0")]

--- a/SKON.NET/SKON.NET/Properties/AssemblyInfo.cs
+++ b/SKON.NET/SKON.NET/Properties/AssemblyInfo.cs
@@ -33,5 +33,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.3.0")]
-[assembly: AssemblyFileVersion("0.1.3.0")]
+[assembly: AssemblyVersion("0.1.4.0")]
+[assembly: AssemblyFileVersion("0.1.4.0")]

--- a/SKON.NET/SKON.NET/SKON.cs
+++ b/SKON.NET/SKON.NET/SKON.cs
@@ -316,13 +316,15 @@ namespace SKON
                 case SKONValueType.ARRAY:
                     StringBuilder arraysb = new StringBuilder();
 
+                    arraysb.Append(indentString);
+
                     if (obj.Length <= 0)
                     {
                         arraysb.Append("[  ]\n");
                         return arraysb.ToString();
                     }
 
-                    arraysb.Append(indentString + "[\n");
+                    arraysb.Append("[\n");
 
                     for (int i = 0; i < obj.Length; i++)
                     {

--- a/SKON.NET/SKON.NET/SKON.cs
+++ b/SKON.NET/SKON.NET/SKON.cs
@@ -320,7 +320,7 @@ namespace SKON
 
                     if (obj.Length <= 0)
                     {
-                        arraysb.Append("[  ]\n");
+                        arraysb.Append("[  ],\n");
                         return arraysb.ToString();
                     }
 

--- a/SKON.NET/SKON.NET/SKONObject.cs
+++ b/SKON.NET/SKON.NET/SKONObject.cs
@@ -426,7 +426,7 @@ namespace SKON
         /// </returns>
         public static implicit operator SKONObject(List<string> list)
         {
-            return new SKONObject(list.ConvertAll(value => (SKONObject)value));
+            return new SKONObject(list?.ConvertAll(value => (SKONObject)value));
         }
 
         /// <summary>
@@ -454,7 +454,7 @@ namespace SKON
         /// </returns>
         public static implicit operator SKONObject(List<int> list)
         {
-            return new SKONObject(list.ConvertAll(value => (SKONObject)value));
+            return new SKONObject(list?.ConvertAll(value => (SKONObject)value));
         }
 
         /// <summary>
@@ -482,7 +482,7 @@ namespace SKON
         /// </returns>
         public static implicit operator SKONObject(List<double> list)
         {
-            return new SKONObject(list.ConvertAll(value => (SKONObject)value));
+            return new SKONObject(list?.ConvertAll(value => (SKONObject)value));
         }
 
         /// <summary>
@@ -510,7 +510,7 @@ namespace SKON
         /// </returns>
         public static implicit operator SKONObject(List<bool> list)
         {
-            return new SKONObject(list.ConvertAll(value => (SKONObject)value));
+            return new SKONObject(list?.ConvertAll(value => (SKONObject)value));
         }
 
         /// <summary>
@@ -538,7 +538,7 @@ namespace SKON
         /// </returns>
         public static implicit operator SKONObject(List<DateTime> list)
         {
-            return new SKONObject(list.ConvertAll(value => (SKONObject)value));
+            return new SKONObject(list?.ConvertAll(value => (SKONObject)value));
         }
 
         /// <summary>

--- a/SKON.NET/SKON.NET/SKONObject.cs
+++ b/SKON.NET/SKON.NET/SKONObject.cs
@@ -190,9 +190,32 @@ namespace SKON
         /// </summary>
         public bool IsEmpty => this.Type == SKONValueType.EMPTY;
 
+        public bool IsSimple
+        {
+            get
+            {
+                switch (this.Type)
+                {
+                    case SKONValueType.STRING:
+                    case SKONValueType.INTEGER:
+                    case SKONValueType.FLOAT:
+                    case SKONValueType.BOOLEAN:
+                    case SKONValueType.DATETIME:
+                        return true;
+                    case SKONValueType.EMPTY:
+                    case SKONValueType.MAP:
+                    case SKONValueType.ARRAY:
+                    default:
+                        return false;
+                }
+            }
+        }
+
+        public bool IsComplex => !IsSimple && !IsEmpty;
+
         /// <summary>
-        /// Gets the collection of string keys, if this SKONObject is a Map, or an empty ICollection, if it isn't.
-        /// </summary>
+    /// Gets the collection of string keys, if this SKONObject is a Map, or an empty ICollection, if it isn't.
+    /// </summary>
         public ICollection<string> Keys => this.Type == SKONValueType.MAP ? new List<string>(mapValues.Keys) : new List<string>();
 
         /// <summary>

--- a/SKON.NET/SKON.NET/SKONObject.cs
+++ b/SKON.NET/SKON.NET/SKONObject.cs
@@ -181,7 +181,7 @@ namespace SKON
         /// <param name="arrayValues">The SKONObject values making up that Array.</param>
         public SKONObject(IEnumerable<SKONObject> arrayValues)
         {
-            this.arrayValues = new List<SKONObject>(arrayValues);
+            this.arrayValues = new List<SKONObject>(arrayValues != null ? arrayValues : new SKONObject[0]);
             this.Type = SKONValueType.ARRAY;
         }
 

--- a/SKON.NET/UnitTests/SKONObjectTests.cs
+++ b/SKON.NET/UnitTests/SKONObjectTests.cs
@@ -665,5 +665,24 @@ namespace UnitTests
 
             Assert.IsTrue(rec1.Equals(rec2));
         }
+
+        [Test]
+        public void NonReqursiveMapWithEqualMaps()
+        {
+            SKONObject skonObject = SKONObject.GetEmptyMap();
+
+            skonObject.Add("test", new List<SKONObject> {
+                new Dictionary<string, SKONObject> {
+                    { "test", 1 }
+                },
+                new Dictionary<string, SKONObject> {
+                    { "test", 1 }
+                }
+            });
+
+            Assert.IsFalse(SKON.ContainsLoops(skonObject));
+
+            Console.WriteLine(SKON.Write(skonObject));
+        }
     }
 }


### PR DESCRIPTION
SKON Objects that had maps that where equal because their contents equal where detected as recursive when they are not. This PR solves this. 
We just want to make sure that the branch itself does not contain an entry that that branch already contains. What happened was that we went through the whole tree and if any object where deemed to contain an object that existed somewhere else (ie, they contained the same data) it reported that the structure was recursive.
The solution (for now) is to create a new HashSet (Dictionary because .net 2.0) for each branch.
This could be made much more efficient with a fixed size array. But this creates a limit to how nested a SKONObejct can be. It could also be done by removing the object itself from the map when its branch is checked. This might actually be the better solution.